### PR TITLE
Add book class

### DIFF
--- a/book.rb
+++ b/book.rb
@@ -1,0 +1,13 @@
+require './item'
+
+class Book < Item
+  attr_reader :publisher, :cover_state
+
+  # rubocop:disable Metrics/ParameterLists
+  def initialize(genre, author, source, label, publish_date, publisher, cover_state)
+    super(genre, author, source, label, publish_date)
+    @publisher = publisher
+    @cover_state = cover_state
+  end
+  # rubocop:enable Metrics/ParameterLists
+end

--- a/book.rb
+++ b/book.rb
@@ -10,4 +10,10 @@ class Book < Item
     @cover_state = cover_state
   end
   # rubocop:enable Metrics/ParameterLists
+
+  def can_be_archived?
+    return true if @cover_state == 'bad'
+
+    super
+  end
 end

--- a/gemfile
+++ b/gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'rubocop', '>= 1.0', '< 2.0'
+gem 'rspec', '~> 3.12'

--- a/gemfile.lock
+++ b/gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    diff-lcs (1.5.0)
     json (2.6.3)
     parallel (1.23.0)
     parser (3.2.2.1)
@@ -9,6 +10,19 @@ GEM
     rainbow (3.1.1)
     regexp_parser (2.8.0)
     rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
     rubocop (1.50.2)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -25,9 +39,11 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  arm64-darwin-22
   x64-mingw-ucrt
 
 DEPENDENCIES
+  rspec (~> 3.12)
   rubocop (>= 1.0, < 2.0)
 
 BUNDLED WITH

--- a/item.rb
+++ b/item.rb
@@ -1,0 +1,2 @@
+class Item
+end

--- a/item.rb
+++ b/item.rb
@@ -1,7 +1,8 @@
 class Item
-  attr_reader :genre, :author, :source, :label, :publish_date, :archived
+  attr_reader :id, :genre, :author, :source, :label, :publish_date, :archived
 
   def initialize(genre, author, source, label, publish_date)
+    @id = Time.now.to_i
     @genre = genre
     @author = author
     @source = source

--- a/item.rb
+++ b/item.rb
@@ -1,5 +1,5 @@
 class Item
-  attr_reader :genre, :author, :source, :label, :publish_date
+  attr_reader :genre, :author, :source, :label, :publish_date, :archived
 
   def initialize(genre, author, source, label, publish_date)
     @genre = genre
@@ -7,6 +7,11 @@ class Item
     @source = source
     @label = label
     @publish_date = publish_date
+    @archived = false
+  end
+
+  def move_to_archive
+    @archived = true if can_be_archived?
   end
 
   private

--- a/item.rb
+++ b/item.rb
@@ -1,2 +1,10 @@
 class Item
+  attr_reader :genre, :author, :source, :label
+
+  def initialize(genre, author, source, label)
+    @genre = genre
+    @author = author
+    @source = source
+    @label = label
+  end
 end

--- a/item.rb
+++ b/item.rb
@@ -1,10 +1,17 @@
 class Item
-  attr_reader :genre, :author, :source, :label
+  attr_reader :genre, :author, :source, :label, :publish_date
 
-  def initialize(genre, author, source, label)
+  def initialize(genre, author, source, label, publish_date)
     @genre = genre
     @author = author
     @source = source
     @label = label
+    @publish_date = publish_date
+  end
+
+  private
+
+  def can_be_archived?
+    Time.now - publish_date > (60 * 60 * 24 * 365 * 10)
   end
 end

--- a/spec/book_spec.rb
+++ b/spec/book_spec.rb
@@ -1,11 +1,16 @@
 require './book'
 
 describe Book do
+  let(:genre) { double('genre') }
+  let(:author) { double('author') }
+  let(:source) { double('source') }
+  let(:label) { double('label') }
+  let(:publish_date) { double('publish_date') }
   let(:publisher) { double('publisher') }
 
   describe '#initialize' do
     it 'creates a new book with publisher and cover_state' do
-      book = Book.new(publisher, 'good')
+      book = Book.new(genre, author, source, label, publish_date, publisher, 'good')
       expect(book.publisher).to eq(publisher)
       expect(book.cover_state).to eq('good')
     end

--- a/spec/book_spec.rb
+++ b/spec/book_spec.rb
@@ -15,4 +15,21 @@ describe Book do
       expect(book.cover_state).to eq('good')
     end
   end
+
+  describe '#can_be_archived?' do
+    it 'expect to return true if Item#can_be_archived? is true' do
+      item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 11), publisher, 'good')
+      expect(item.send(:can_be_archived?)).to eq(true)
+    end
+
+    it 'expect to return true if cover_state equals "bad"' do
+      item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 9), publisher, 'bad')
+      expect(item.send(:can_be_archived?)).to eq(true)
+    end
+
+    it 'expect to return false if if Item#can_be_archived? is false and cover_state equals "good"' do
+      item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 9), publisher, 'good')
+      expect(item.send(:can_be_archived?)).to eq(false)
+    end
+  end
 end

--- a/spec/book_spec.rb
+++ b/spec/book_spec.rb
@@ -18,18 +18,18 @@ describe Book do
 
   describe '#can_be_archived?' do
     it 'expect to return true if Item#can_be_archived? is true' do
-      item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 11), publisher, 'good')
-      expect(item.send(:can_be_archived?)).to eq(true)
+      book = Book.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 11), publisher, 'good')
+      expect(book.send(:can_be_archived?)).to eq(true)
     end
 
     it 'expect to return true if cover_state equals "bad"' do
-      item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 9), publisher, 'bad')
-      expect(item.send(:can_be_archived?)).to eq(true)
+      book = Book.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 9), publisher, 'bad')
+      expect(book.send(:can_be_archived?)).to eq(true)
     end
 
     it 'expect to return false if if Item#can_be_archived? is false and cover_state equals "good"' do
-      item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 9), publisher, 'good')
-      expect(item.send(:can_be_archived?)).to eq(false)
+      book = Book.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 9), publisher, 'good')
+      expect(book.send(:can_be_archived?)).to eq(false)
     end
   end
 end

--- a/spec/book_spec.rb
+++ b/spec/book_spec.rb
@@ -1,0 +1,13 @@
+require './book'
+
+describe Book do
+  let(:publisher) { double('publisher') }
+
+  describe '#initialize' do
+    it 'creates a new book with publisher and cover_state' do
+      book = Book.new(publisher, 'good')
+      expect(book.publisher).to eq(publisher)
+      expect(book.cover_state).to eq('good')
+    end
+  end
+end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -8,13 +8,14 @@ describe Item do
   let(:publish_date) { double('publish_date') }
 
   describe '#initialize' do
-    it 'creates a new item with genre, author, source, and label' do
+    it 'creates a new item with genre, author, source, label, publish_date' do
       item = Item.new(genre, author, source, label, publish_date)
       expect(item.genre).to eq genre
       expect(item.author).to eq author
       expect(item.source).to eq source
       expect(item.label).to eq label
       expect(item.publish_date).to eq publish_date
+      expect(item.archived).to eq(false)
     end
   end
 
@@ -33,6 +34,7 @@ describe Item do
   describe '#move_to_archive' do
     it 'should change the archived property to true if #can_be_archived? is true' do
       item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 11))
+      item.move_to_archive
       expect(item.archived).to eq(true)
     end
   end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -15,13 +15,4 @@ describe Item do
       expect(item.label).to eq label
     end
   end
-
-  describe '#add_genre' do
-    it 'adds a genre with the name "test" to item' do
-      item = Item.new(genre, author, source, label)
-      name = 'test'
-      item.add_genre(name)
-      expect(item.genre).to eq name
-    end
-  end
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -1,18 +1,27 @@
 require './item'
 
 describe Item do
-  describe '#initialize' do
-    let(:genre) { double('genre') }
-    let(:author) { double('author') }
-    let(:source) { double('source') }
-    let(:label) { double('label') }
+  let(:genre) { double('genre') }
+  let(:author) { double('author') }
+  let(:source) { double('source') }
+  let(:label) { double('label') }
 
+  describe '#initialize' do
     it 'creates a new item with genre, author, source, and label' do
       item = Item.new(genre, author, source, label)
       expect(item.genre).to eq genre
       expect(item.author).to eq author
       expect(item.source).to eq source
       expect(item.label).to eq label
+    end
+  end
+
+  describe '#add_genre' do
+    it 'adds a genre with the name "test" to item' do
+      item = Item.new(genre, author, source, label)
+      name = 'test'
+      item.add_genre(name)
+      expect(item.genre).to eq name
     end
   end
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -21,12 +21,12 @@ describe Item do
   describe '#can_be_archived?' do
     it 'expect to return true if publish_date is older than 10 years' do
       item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 11))
-      expect(item.can_be_archived?).to eq(true)
+      expect(item.send(:can_be_archived?)).to eq(true)
     end
 
     it 'expect to return false if publish_date is not older than 10 years' do
       item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 9))
-      expect(item.can_be_archived?).to eq(false)
+      expect(item.send(:can_be_archived?)).to eq(false)
     end
   end
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -1,4 +1,18 @@
 require './item'
 
 describe Item do
+  describe '#initialize' do
+    let(:genre) { double('genre') }
+    let(:author) { double('author') }
+    let(:source) { double('source') }
+    let(:label) { double('label') }
+
+    it 'creates a new item with genre, author, source, and label' do
+      item = Item.new(genre, author, source, label)
+      expect(item.genre).to eq genre
+      expect(item.author).to eq author
+      expect(item.source).to eq source
+      expect(item.label).to eq label
+    end
+  end
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -5,14 +5,28 @@ describe Item do
   let(:author) { double('author') }
   let(:source) { double('source') }
   let(:label) { double('label') }
+  let(:publish_date) { double('publish_date') }
 
   describe '#initialize' do
     it 'creates a new item with genre, author, source, and label' do
-      item = Item.new(genre, author, source, label)
+      item = Item.new(genre, author, source, label, publish_date)
       expect(item.genre).to eq genre
       expect(item.author).to eq author
       expect(item.source).to eq source
       expect(item.label).to eq label
+      expect(item.publish_date).to eq publish_date
+    end
+  end
+
+  describe '#can_be_archived?' do
+    it 'expect to return true if publish_date is older than 10 years' do
+      item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 11))
+      expect(item.can_be_archived?).to eq(true)
+    end
+
+    it 'expect to return false if publish_date is not older than 10 years' do
+      item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 9))
+      expect(item.can_be_archived?).to eq(false)
     end
   end
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -1,0 +1,4 @@
+require './item'
+
+describe Item do
+end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -29,4 +29,11 @@ describe Item do
       expect(item.send(:can_be_archived?)).to eq(false)
     end
   end
+
+  describe '#move_to_archive' do
+    it 'should change the archived property to true if #can_be_archived? is true' do
+      item = Item.new(genre, author, source, label, Time.now - (60 * 60 * 24 * 365 * 11))
+      expect(item.archived).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
In this pull request, we completed the following:

All Book class properties visible in the diagram should be defined and set up in the constructor method.

#### Implement methods:
### can_be_archived?() in the Book class
- should override the method from the parent class
- should return true if parent's method returns true OR if cover_state equals to "bad"
- otherwise, it should return false